### PR TITLE
Simple Multisampling

### DIFF
--- a/src/generator/color.rs
+++ b/src/generator/color.rs
@@ -1,89 +1,97 @@
+use cgmath::Vector4;
 use std::mem::transmute;
 
-/// Represents an RGBA color, with 8 bits per channel.
-#[repr(C)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub struct RGBAColor {
-    pub r: u8,
-    pub g: u8,
-    pub b: u8,
-    pub a: u8,
-}
+/// Trait for any color that can be created by converting HSBA values into RGBA
+/// values.
+pub trait FromHSBA: Sized {
+    type Element: Clone;
 
-impl RGBAColor {
-    /// Creates a new RGBAColor from the given color byte values.
-    pub fn new(red: u8, green: u8, blue: u8, alpha: u8) -> RGBAColor {
-        RGBAColor {
-            r: red,
-            g: green,
-            b: blue,
-            a: alpha,
-        }
-    }
+    /// Converts a f32 into this color's internal element type.
+    fn f32_to_element(value: f32) -> Self::Element;
 
-    /// Creates a new RGBAColor from these HSBA values. All HSBA values must be
-    /// in the range 0..1.
-    pub fn from_hsb(hue: f32, saturation: f32, brightness: f32, alpha: f32) -> RGBAColor {
-        let alpha = (alpha * 255f32 + 0.5f32) as u8;
+    /// Creates an instance of this color from RGBA values.
+    fn compose(r: Self::Element, g: Self::Element, b: Self::Element, a: Self::Element) -> Self;
+
+    /// Creates an instance of this color from HSBA values. All HSBA values must
+    /// be in the range 0..1.
+    fn from_hsba(hue: f32, saturation: f32, brightness: f32, alpha: f32) -> Self {
+        let alpha = Self::f32_to_element(alpha);
         if saturation == 0f32 {
-            let brightness = (brightness * 255f32 + 0.5f32) as u8;
-            RGBAColor {
-                r: brightness,
-                g: brightness,
-                b: brightness,
-                a: alpha,
-            }
+            let brightness = Self::f32_to_element(brightness);
+            Self::compose(brightness.clone(), brightness.clone(), brightness, alpha)
         } else {
             let sector = (hue % 1f32) * 6f32;
             let offset_in_sector = sector - sector.floor();
             let off = brightness * (1f32 - saturation);
             let fade_out = brightness * (1f32 - saturation * offset_in_sector);
             let fade_in = brightness * (1f32 - saturation * (1f32 - offset_in_sector));
+            let brightness = Self::f32_to_element(brightness);
+            let off = Self::f32_to_element(off);
             match sector as u32 {
-                0 => RGBAColor {
-                    r: (brightness * 255f32 + 0.5f32) as u8,
-                    g: (fade_in * 255f32 + 0.5f32) as u8,
-                    b: (off * 255f32 + 0.5f32) as u8,
-                    a: alpha,
-                },
-                1 => RGBAColor {
-                    r: (fade_out * 255f32 + 0.5f32) as u8,
-                    g: (brightness * 255f32 + 0.5f32) as u8,
-                    b: (off * 255f32 + 0.5f32) as u8,
-                    a: alpha,
-                },
-                2 => RGBAColor {
-                    r: (off * 255f32 + 0.5f32) as u8,
-                    g: (brightness * 255f32 + 0.5f32) as u8,
-                    b: (fade_in * 255f32 + 0.5f32) as u8,
-                    a: alpha,
-                },
-                3 => RGBAColor {
-                    r: (off * 255f32 + 0.5f32) as u8,
-                    g: (fade_out * 255f32 + 0.5f32) as u8,
-                    b: (brightness * 255f32 + 0.5f32) as u8,
-                    a: alpha,
-                },
-                4 => RGBAColor {
-                    r: (fade_in * 255f32 + 0.5f32) as u8,
-                    g: (off * 255f32 + 0.5f32) as u8,
-                    b: (brightness * 255f32 + 0.5f32) as u8,
-                    a: alpha,
-                },
-                5 => RGBAColor {
-                    r: (brightness * 255f32 + 0.5f32) as u8,
-                    g: (off * 255f32 + 0.5f32) as u8,
-                    b: (fade_out * 255f32 + 0.5f32) as u8,
-                    a: alpha,
-                },
+                0 => Self::compose(brightness, Self::f32_to_element(fade_in), off, alpha),
+                1 => Self::compose(Self::f32_to_element(fade_out), brightness, off, alpha),
+                2 => Self::compose(off, brightness, Self::f32_to_element(fade_in), alpha),
+                3 => Self::compose(off, Self::f32_to_element(fade_out), brightness, alpha),
+                4 => Self::compose(Self::f32_to_element(fade_in), off, brightness, alpha),
+                5 => Self::compose(brightness, off, Self::f32_to_element(fade_out), alpha),
                 _ => unreachable!("Invalid color wheel sector {}", sector),
             }
         }
     }
 }
 
-impl From<RGBAColor> for [u8; 4] {
-    fn from(c: RGBAColor) -> Self {
+impl FromHSBA for RGBA8Color {
+    type Element = u8;
+
+    fn f32_to_element(value: f32) -> Self::Element {
+        (value * 255f32 + 0.5f32) as u8
+    }
+
+    fn compose(r: Self::Element, g: Self::Element, b: Self::Element, a: Self::Element) -> Self {
+        RGBA8Color { r, g, b, a }
+    }
+}
+
+impl FromHSBA for Vector4<f32> {
+    type Element = f32;
+
+    fn f32_to_element(value: f32) -> Self::Element {
+        value
+    }
+
+    fn compose(r: Self::Element, g: Self::Element, b: Self::Element, a: Self::Element) -> Self {
+        Vector4 {
+            x: r,
+            y: g,
+            z: b,
+            w: a,
+        }
+    }
+}
+
+/// Represents an RGBA color, with 8 bits per channel.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct RGBA8Color {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+    pub a: u8,
+}
+
+impl From<Vector4<f32>> for RGBA8Color {
+    fn from(v: Vector4<f32>) -> Self {
+        RGBA8Color {
+            r: Self::f32_to_element(v.x),
+            g: Self::f32_to_element(v.y),
+            b: Self::f32_to_element(v.z),
+            a: Self::f32_to_element(v.w),
+        }
+    }
+}
+
+impl From<RGBA8Color> for [u8; 4] {
+    fn from(c: RGBA8Color) -> Self {
         unsafe { transmute(c) }
     }
 }

--- a/src/generator/cpu/opts.rs
+++ b/src/generator/cpu/opts.rs
@@ -1,6 +1,11 @@
-use crate::generator::{args::Smoothing, color::RGBAColor, view::View, FractalOpts};
+use crate::generator::{
+    args::{Smoothing, DEFAULT_RADIUS_SQUARED},
+    color::FromHSBA,
+    view::View,
+    FractalOpts,
+};
+use cgmath::Vector4;
 use num_complex::Complex;
-use crate::generator::args::DEFAULT_RADIUS_SQUARED;
 
 /// Structs implementing this trait can be used to generate pixel colors on a
 /// CPU.
@@ -10,15 +15,15 @@ pub trait CpuFractalOpts {
     fn gen_value(&self, loc: Complex<f32>) -> f32;
 
     /// Generates a color from a iteration count value.
-    fn gen_color(&self, value: f32) -> RGBAColor;
+    fn gen_color(&self, value: f32) -> Vector4<f32>;
 
     /// Generates an iteration count value for a given pixel location and view.
-    fn gen_pixel_value(&self, view: View, x: usize, y: usize) -> f32 {
-        self.gen_value(view.get_local_plane_coordinates((x, y)))
+    fn gen_pixel_value(&self, view: View, x: f32, y: f32) -> f32 {
+        self.gen_value(view.get_local_subpixel_plane_coordinates((x, y)))
     }
 
     /// Generates a pixel color for a given pixel location and view.
-    fn gen_pixel(&self, view: View, x: usize, y: usize) -> RGBAColor {
+    fn gen_pixel(&self, view: View, x: f32, y: f32) -> Vector4<f32> {
         self.gen_color(self.gen_pixel_value(view, x, y))
     }
 }
@@ -55,16 +60,21 @@ impl CpuFractalOpts for FractalOpts {
         }
     }
 
-    fn gen_color(&self, value: f32) -> RGBAColor {
+    fn gen_color(&self, value: f32) -> Vector4<f32> {
         if value < self.iterations as f32 {
-            RGBAColor::from_hsb(
+            Vector4::<f32>::from_hsba(
                 value * 3.3f32 / 256f32 % 1f32,
                 1f32,
                 value * 16f32 / 256f32 % 1f32,
                 1f32,
             )
         } else {
-            RGBAColor::new(0, 0, 0, 255)
+            Vector4::<f32> {
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
+                w: 1.0,
+            }
         }
     }
 }

--- a/src/generator/gpu/shader/mod.rs
+++ b/src/generator/gpu/shader/mod.rs
@@ -46,4 +46,6 @@ pub enum ShaderError {
     MissingTemplateFunction(String),
     #[error("Missing template constant '{}'", .0)]
     MissingTemplateConstant(String),
+    #[error("Missing template type '{}'", .0)]
+    MissingTemplateType(String),
 }

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -7,7 +7,10 @@ pub mod row_stitcher;
 pub mod util;
 pub mod view;
 
-use crate::generator::{args::Smoothing, view::View};
+use crate::generator::{
+    args::{Multisampling, Smoothing},
+    view::View,
+};
 use futures::future::BoxFuture;
 use num_complex::Complex;
 use std::mem::size_of;
@@ -21,6 +24,7 @@ pub struct FractalOpts {
     pub mandelbrot: bool,
     pub iterations: u32,
     pub smoothing: Smoothing,
+    pub multisampling: Multisampling,
     pub c: Complex<f32>,
 }
 

--- a/src/generator/util.rs
+++ b/src/generator/util.rs
@@ -1,4 +1,6 @@
 use crate::generator::BYTES_PER_PIXEL;
+use cgmath::Vector2;
+use core::mem;
 use num_traits::One;
 use std::ops::{Add, Div, Mul, Sub};
 
@@ -44,6 +46,77 @@ pub fn copy_region(
         let si = (sy * src_width + src_x) * BYTES_PER_PIXEL;
         let di = (dy * dest_width + dest_x) * BYTES_PER_PIXEL;
         dest[di..di + strip_size].copy_from_slice(&src[si..si + strip_size]);
+    }
+}
+
+/// Builds an array of offsets for the four-point multisampling scheme.
+pub fn build_four_points_offsets(offset: f32) -> Vec<Vector2<f32>> {
+    vec![
+        Vector2 {
+            x: -offset,
+            y: -offset,
+        },
+        Vector2 {
+            x: offset,
+            y: -offset,
+        },
+        Vector2 {
+            x: -offset,
+            y: offset,
+        },
+        Vector2 {
+            x: offset,
+            y: offset,
+        },
+    ]
+}
+
+/// Builds an array of offsets for the linear multisampling scheme.
+pub fn build_linear_offsets(axial_points: u32) -> Vec<Vector2<f32>> {
+    let mut vec = vec![];
+
+    let offset = 1.0 / axial_points as f32;
+    let initial_offset = offset / 2.0;
+
+    for y in 0..axial_points {
+        for x in 0..axial_points {
+            vec.push(Vector2 {
+                x: x as f32 * offset + initial_offset - 0.5,
+                y: y as f32 * offset + initial_offset - 0.5,
+            })
+        }
+    }
+
+    vec
+}
+
+/// Designed to allow the use of `f32` and `f64` as map keys.
+#[derive(Debug, Copy, Clone, PartialOrd, PartialEq, Ord, Eq, Hash)]
+pub struct FloatKey {
+    mantissa: u64,
+    exponent: i16,
+    sign: i8,
+}
+
+impl FloatKey {
+    /// Constructs a FloatKey from a f32.
+    pub fn from_f32(value: f32) -> FloatKey {
+        let bits: u32 = unsafe { mem::transmute(value) };
+        let sign: i8 = if bits >> 31 == 0 { 1 } else { -1 };
+        let mut exponent: i16 = ((bits >> 23) & 0xff) as i16;
+        let mantissa = if exponent == 0 {
+            (bits & 0x7fffff) << 1
+        } else {
+            (bits & 0x7fffff) | 0x800000
+        };
+        // Exponent bias + mantissa shift
+        exponent -= 127 + 23;
+
+        FloatKey {
+            mantissa: mantissa as u64,
+            exponent,
+            sign,
+        }
     }
 }
 

--- a/src/generator/view.rs
+++ b/src/generator/view.rs
@@ -101,6 +101,15 @@ impl View {
         )
     }
 
+    /// Gets the coordinates on the complex plane for a given local subpixel
+    /// pixel coordinate.
+    pub fn get_local_subpixel_plane_coordinates(&self, (x, y): (f32, f32)) -> Complex<f32> {
+        Complex::<f32>::new(
+            x * self.image_scale_x + self.plane_start_x,
+            y * self.image_scale_y + self.plane_start_y,
+        )
+    }
+
     /// Gets the local pixel coordinates for a given coordinate on the complex
     /// plane.
     pub fn get_local_pixel_coordinates(

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ use std::{
 };
 use tokio::{sync::mpsc, task};
 use wgpu::{BackendBit, Instance, Maintain, RequestAdapterOptions};
+use crate::generator::args::Multisampling;
 
 mod generator;
 mod logging;
@@ -44,6 +45,7 @@ async fn main() {
         mandelbrot: false,
         iterations: 200,
         smoothing: Smoothing::from_logarithmic_distance(4.0, 2.0),
+        multisampling: Multisampling::Linear { axial_points: 16 },
         c: Complex32 {
             re: 0.16611,
             im: 0.59419,


### PR DESCRIPTION
This PR adds simple multisampling options and abilities to both CPU and GPU generators.

The branches of 5bc70f4be5354e706af18778a114ef9da03662f9 and 5e2972b4d0ced4d110690350a3d5d3e90c72b84c allocate large framebuffer arrays and create large amounts of render-passes per frame, causing significant memory usage and decreased speed.

Instead, this form of GPU multisampling does all sampling and blending in the `template.wgsl` shader, meaning that it does not use much extra memory and is almost as fast as if multisampling were disabled.

The CPU generator does not perform very well when multisampling is enabled, but multisampling-disabled performance is relatively unaffected.