### PR TITLE
Improve CPU usage and only use async where necessary

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -49,9 +49,9 @@ struct FractalRSGuiMain {
     ui: FractalRSUI,
 }
 
-#[async_trait]
 impl FlowModel for FractalRSGuiMain {
-    async fn init(init: FlowModelInit) -> Self {
+    fn init(init: FlowModelInit) -> Self {
+        let handle = init.handle;
         let device = init.device;
         let queue = init.queue;
         let window = init.window;
@@ -74,6 +74,7 @@ impl FlowModel for FractalRSGuiMain {
 
         info!("Initializing UI State...");
         let ui = FractalRSUI::new(UICreationContext {
+            handle,
             device: device.clone(),
             queue: queue.clone(),
             render_pass: &mut render_pass,
@@ -94,7 +95,7 @@ impl FlowModel for FractalRSGuiMain {
         }
     }
 
-    async fn event(&mut self, event: &WindowEvent<'_>) -> Option<FlowSignal> {
+    fn event(&mut self, event: &WindowEvent<'_>) -> Option<FlowSignal> {
         if let WindowEvent::Resized(new_size) = event {
             self.window_size = *new_size;
         }
@@ -119,11 +120,11 @@ impl FlowModel for FractalRSGuiMain {
         None
     }
 
-    async fn all_events(&mut self, event: &Event<FlowSignal>) {
+    fn all_events(&mut self, event: &Event<FlowSignal>) {
         self.platform.handle_event(event);
     }
 
-    async fn update(&mut self, _update_delta: Duration) -> Option<FlowSignal> {
+    fn update(&mut self, _update_delta: Duration) -> Option<FlowSignal> {
         self.ui.update();
 
         if self.ui.close_requested {
@@ -140,7 +141,7 @@ impl FlowModel for FractalRSGuiMain {
         }
     }
 
-    async fn render(&mut self, frame_view: &TextureView, _render_delta: Duration) {
+    fn render(&mut self, frame_view: &TextureView, _render_delta: Duration) {
         // Setup platform for frame
         self.platform
             .update_time(self.start_time.elapsed().as_secs_f64());
@@ -205,5 +206,5 @@ impl FlowModel for FractalRSGuiMain {
         self.queue.submit(self.commands.drain(..));
     }
 
-    async fn shutdown(self) {}
+    fn shutdown(self) {}
 }

--- a/src/gui/ui/instance.rs
+++ b/src/gui/ui/instance.rs
@@ -12,6 +12,7 @@ use egui::{vec2, DragValue, ProgressBar, Ui};
 use egui_wgpu_backend::RenderPass;
 use num_complex::Complex32;
 use std::{borrow::Cow, sync::Arc};
+use tokio::runtime::Handle;
 use wgpu::{Device, Queue};
 
 const MAX_CHUNK_WIDTH: usize = 256;
@@ -59,6 +60,8 @@ pub struct UIInstance {
 pub struct UIInstanceCreationContext<'a, S: ToString> {
     /// The name of this ui instance.
     pub name: S,
+    /// Runtime handle for running async tasks.
+    pub handle: Handle,
     /// Device reference.
     pub device: Arc<Device>,
     /// Queue reference.
@@ -118,7 +121,7 @@ impl UIInstance {
         let center_x = ctx.initial_settings.view.plane_start_x + plane_width / 2.0;
         let center_y = ctx.initial_settings.view.plane_start_y + plane_height / 2.0;
 
-        let manager = GeneratorManager::new(ctx.factory);
+        let manager = GeneratorManager::new(ctx.handle, ctx.factory);
 
         let viewer = FractalViewer::new(&ctx.device, ctx.render_pass, ctx.initial_settings.view);
 

--- a/src/gui/ui/mod.rs
+++ b/src/gui/ui/mod.rs
@@ -13,12 +13,14 @@ use crate::{
 use egui::{CtxRef, Layout, ScrollArea};
 use egui_wgpu_backend::RenderPass;
 use std::sync::Arc;
+use tokio::runtime::Handle;
 use wgpu::{Device, Queue};
 use winit::event::VirtualKeyCode;
 
 /// Struct specifically devoted to UI rendering and state.
 pub struct FractalRSUI {
     // needed for creating new instances
+    handle: Handle,
     device: Arc<Device>,
     queue: Arc<Queue>,
 
@@ -49,6 +51,8 @@ pub struct FractalRSUI {
 
 /// Struct containing context passed when creating UIState.
 pub struct UICreationContext<'a> {
+    /// Runtime handle reference.
+    pub handle: Handle,
     /// Device reference.
     pub device: Arc<Device>,
     /// Queue reference.
@@ -79,6 +83,7 @@ impl FractalRSUI {
 
         let first_instance = UIInstance::new(UIInstanceCreationContext {
             name: "Fractal 1",
+            handle: ctx.handle.clone(),
             device: ctx.device.clone(),
             queue: ctx.queue.clone(),
             factory: factory.clone(),
@@ -87,6 +92,7 @@ impl FractalRSUI {
         });
 
         FractalRSUI {
+            handle: ctx.handle.clone(),
             device: ctx.device,
             queue: ctx.queue,
             close_requested: false,
@@ -257,6 +263,7 @@ impl FractalRSUI {
             // it.
             let new_instance = UIInstance::new(UIInstanceCreationContext {
                 name: format!("Fractal {}", self.instance_name_index),
+                handle: self.handle.clone(),
                 device: self.device.clone(),
                 queue: self.queue.clone(),
                 factory: self.factory.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,6 @@
 #![feature(never_type)]
 
 #[macro_use]
-extern crate async_trait;
-#[macro_use]
 extern crate log;
 #[macro_use]
 extern crate serde;


### PR DESCRIPTION
This does two things. First, this makes it so that `Flow` no longer runs `Model` methods inside a tokio runtime. This is helpful as it reduces the inter-thread communication every frame. Second, this slows the rate at which the GPU Device is polled so at not to waste CPU.