### PR TITLE
Move logging, config, and debugging files to consistent location

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,6 +586,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,6 +739,7 @@ dependencies = [
  "cgmath",
  "chrono",
  "chrono-humanize",
+ "dirs 4.0.0",
  "egui",
  "egui_wgpu_backend",
  "egui_winit_platform",
@@ -2728,7 +2738,7 @@ version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a23fe958c70412687039c86f578938b4a0bb50ec788e96bce4d6ab00ddd5803"
 dependencies = [
- "dirs",
+ "dirs 3.0.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ bytemuck = "^1.7.2"
 chrono = "^0.4.19"
 chrono-humanize = "^0.2.1"
 cgmath = "^0.18.0"
+dirs = "^4.0.0"
 egui = "^0.15.0"
 egui_wgpu_backend = { git = "https://github.com/Kneelawk/egui_wgpu_backend.git", branch = "textureid-with-sampler-options" }
 egui_winit_platform = { version = "^0.11.0", features = ["clipboard", "webbrowser"] }

--- a/src/generator/gpu/shader/mod.rs
+++ b/src/generator/gpu/shader/mod.rs
@@ -1,6 +1,9 @@
 pub mod opts;
 
-use crate::generator::{gpu::shader::opts::GpuFractalOpts, FractalOpts};
+use crate::{
+    generator::{gpu::shader::opts::GpuFractalOpts, FractalOpts},
+    util::files::debug_dir,
+};
 use naga::{
     back, front,
     valid::{ValidationFlags, Validator},
@@ -18,7 +21,7 @@ pub async fn load_shaders(opts: FractalOpts) -> anyhow::Result<ShaderSource<'sta
     opts.install(&mut module)?;
 
     info!("Writing module as txt...");
-    let mut file = File::create("debug.txt").await.unwrap();
+    let mut file = File::create(debug_dir().join("debug.txt")).await.unwrap();
     file.write_all(format!("{:#?}", &module).as_bytes())
         .await
         .unwrap();
@@ -34,7 +37,7 @@ pub async fn load_shaders(opts: FractalOpts) -> anyhow::Result<ShaderSource<'sta
     writer.finish();
 
     info!("Writing WGSL...");
-    let mut wgsl_file = File::create("debug.wgsl").await.unwrap();
+    let mut wgsl_file = File::create(debug_dir().join("debug.wgsl")).await.unwrap();
     wgsl_file.write_all(wgsl_str.as_bytes()).await.unwrap();
 
     Ok(ShaderSource::Wgsl(Cow::Owned(wgsl_str)))

--- a/src/gui/util.rs
+++ b/src/gui/util.rs
@@ -6,7 +6,7 @@ pub async fn get_trace_path(
     typename: impl AsRef<str>,
     start_date: bool,
 ) -> Result<Option<PathBuf>, io::Error> {
-    use crate::util::get_start_date;
+    use crate::util::{files::logs_dir, get_start_date};
     use chrono::Local;
     use std::borrow::Cow;
     use tokio::fs::create_dir_all;
@@ -17,8 +17,8 @@ pub async fn get_trace_path(
         Cow::Owned(Local::now())
     };
 
-    let path = PathBuf::from(format!(
-        "logs/log-{}-{}.trace",
+    let path = logs_dir().join(format!(
+        "log-{}-{}.trace",
         date.format("%Y-%m-%d_%H-%M-%S").to_string(),
         typename.as_ref()
     ));

--- a/src/logging/default.log4rs.yaml
+++ b/src/logging/default.log4rs.yaml
@@ -13,7 +13,7 @@ appenders:
       - kind: threshold
         level: debug
     append: false
-    path: "logs/log-{D}.log"
+    path: "{l}/log-{D}.log"
     encoder:
       pattern: "[{d(%m-%d-%Y %H:%M:%S)} {l} {M}] {m}{n}"
 

--- a/src/logging/fancy_file.rs
+++ b/src/logging/fancy_file.rs
@@ -1,4 +1,4 @@
-use crate::util::get_start_date;
+use crate::util::{files::logs_dir, get_start_date};
 use log4rs::{
     append::{file::FileAppender, Append},
     config::{Deserialize, Deserializers},
@@ -35,19 +35,21 @@ impl Deserialize for FancyFileAppenderDeserializer {
         if let Some(encoder) = config.encoder {
             appender = appender.encoder(deserializers.deserialize(&encoder.kind, encoder.config)?);
         }
-        Ok(Box::new(appender.build(&expand_dates(config.path.into()))?))
+        Ok(Box::new(
+            appender.build(&expand_templates(config.path.into()))?,
+        ))
     }
 }
 
 lazy_static::lazy_static! {
-static ref DATE_EXPANSION_PATTERN: Regex = Regex::new(r#"\{(?P<type>\w)(\((?P<args>[^)]+)\))?\}"#).unwrap();
+static ref TEMPLATE_EXPANSION_PATTERN: Regex = Regex::new(r#"\{(?P<type>\w)(\((?P<args>[^)]+)\))?\}"#).unwrap();
 }
 
-fn expand_dates(path: PathBuf) -> PathBuf {
+fn expand_templates(path: PathBuf) -> PathBuf {
     let mut path = path.to_string_lossy().to_string();
 
-    for c in DATE_EXPANSION_PATTERN.captures_iter(&path.clone()) {
-        if let Some(str) = expand_date(
+    for c in TEMPLATE_EXPANSION_PATTERN.captures_iter(&path.clone()) {
+        if let Some(str) = expand_template(
             c.name("type").unwrap().as_str(),
             c.name("args").map(|m| m.as_str()),
         ) {
@@ -58,7 +60,7 @@ fn expand_dates(path: PathBuf) -> PathBuf {
     path.into()
 }
 
-fn expand_date(ty: &str, args: Option<&str>) -> Option<String> {
+fn expand_template(ty: &str, args: Option<&str>) -> Option<String> {
     match ty {
         "d" => Some(
             chrono::Local::now()
@@ -70,6 +72,7 @@ fn expand_date(ty: &str, args: Option<&str>) -> Option<String> {
                 .format(args.unwrap_or("%Y-%m-%d_%H-%M-%S"))
                 .to_string(),
         ),
+        "l" => Some(logs_dir().to_string_lossy().to_string()),
         _ => None,
     }
 }

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -1,19 +1,19 @@
 mod fancy_file;
 
-use crate::logging::fancy_file::FancyFileAppenderDeserializer;
+use crate::{logging::fancy_file::FancyFileAppenderDeserializer, util::files::config_dir};
 use log4rs::config::Deserializers;
-use std::{fs::OpenOptions, io::Write, path::Path};
+use std::{fs::OpenOptions, io::Write};
 
 const DEFAULT_CONFIG_FILE: &str = "fractal-rs-2.log4rs.yaml";
 const DEFAULT_CONFIG: &[u8] = include_bytes!("default.log4rs.yaml");
 
 pub fn init() {
-    let config_file_path = Path::new(DEFAULT_CONFIG_FILE);
+    let config_file_path = config_dir().join(DEFAULT_CONFIG_FILE);
     if !config_file_path.exists() {
         let mut write_cfg_file = OpenOptions::new()
             .write(true)
             .create(true)
-            .open(config_file_path)
+            .open(&config_file_path)
             .unwrap();
         write_cfg_file.write_all(DEFAULT_CONFIG).unwrap();
     }
@@ -21,5 +21,5 @@ pub fn init() {
     let mut deserializers = Deserializers::new();
     deserializers.insert("fancy_file", FancyFileAppenderDeserializer);
 
-    log4rs::init_file(config_file_path, deserializers).unwrap();
+    log4rs::init_file(&config_file_path, deserializers).unwrap();
 }

--- a/src/util/files.rs
+++ b/src/util/files.rs
@@ -1,0 +1,35 @@
+use crate::util::result::ResultExt;
+use std::{fs::create_dir_all, path::PathBuf};
+
+const STORAGE_DIR_NAME: &str = ".fractal-rs-2";
+const CONFIG_DIR_NAME: &str = "config";
+const DEBUG_DIR_NAME: &str = "debug";
+const LOGS_DIR_NAME: &str = "logs";
+
+pub fn fractal_rs_2_dir() -> Option<PathBuf> {
+    dirs::home_dir().map(|p| p.join(STORAGE_DIR_NAME))
+}
+
+pub fn config_dir() -> PathBuf {
+    let dir = fractal_rs_2_dir()
+        .map(|p| p.join(CONFIG_DIR_NAME))
+        .unwrap_or(PathBuf::from(CONFIG_DIR_NAME));
+    create_dir_all(&dir).on_err(|e| error!("Error creating config dir: {:?}", e));
+    dir
+}
+
+pub fn debug_dir() -> PathBuf {
+    let dir = fractal_rs_2_dir()
+        .map(|p| p.join(DEBUG_DIR_NAME))
+        .unwrap_or(PathBuf::from(DEBUG_DIR_NAME));
+    create_dir_all(&dir).on_err(|e| error!("Error debug config dir: {:?}", e));
+    dir
+}
+
+pub fn logs_dir() -> PathBuf {
+    let dir = fractal_rs_2_dir()
+        .map(|p| p.join(LOGS_DIR_NAME))
+        .unwrap_or(PathBuf::from(LOGS_DIR_NAME));
+    create_dir_all(&dir).on_err(|e| error!("Error logs config dir: {:?}", e));
+    dir
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -3,6 +3,7 @@
 pub mod future;
 pub mod result;
 pub mod running_guard;
+pub mod files;
 
 use chrono::{DateTime, Local, Utc};
 use chrono_humanize::{Accuracy, HumanTime, Tense};


### PR DESCRIPTION
This PR moves logging, config, and debugging files into a `.fractal-rs-2` directory in the user's home directory. I am deciding to keep the location consistent on all platforms because I find it annoying when applications put their config files in hard-to-find places on each platform. This way it is simple.